### PR TITLE
[semver:patch] fix(examples): add workflow steps to fix examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is an Orb plugin to simplify running builds using [LocalStack](https://gith
 ## Resources
 
 [CircleCI Orb Registry Page](https://circleci.com/orbs/registry/orb/localstack/platform) - The official registry page of this orb for all versions, executors, commands, and jobs described.
+
 [CircleCI Orb Docs](https://circleci.com/docs/2.0/orb-intro/#section=configuration) - Docs for using and creating CircleCI Orbs.
 
 ### How to Publish

--- a/src/examples/aws-cli-commands.yml
+++ b/src/examples/aws-cli-commands.yml
@@ -1,7 +1,8 @@
 description: |
   This example runs a simple LocalStack build that manages S3 buckets and objects locally.
 
-  The sample below uses the `awslocal` CLI command, a drop-in replacement of the `aws` CLI, for use with local APIs on `localhost`. The sample contains 2 steps: first, it starts up LocalStack via the `localstack/startup` command; second, it runs the commands to interact with the local S3 API provided by LocalStack.
+  The sample below uses the `awslocal` CLI command, a drop-in replacement of the `aws` CLI, for use with local APIs on `localhost`.
+  The sample contains 2 steps: first, it starts up LocalStack via the `localstack/startup` command; second, it runs the commands to interact with the local S3 API provided by LocalStack.
 
 usage:
   version: 2.1
@@ -23,4 +24,3 @@ usage:
     localstack-test:
       jobs:
         - localstack-test
-      

--- a/src/examples/aws-cli-commands.yml
+++ b/src/examples/aws-cli-commands.yml
@@ -18,3 +18,9 @@ usage:
             command: |
               awslocal s3 mb s3://test
               awslocal s3 ls
+
+  workflows:
+    localstack-test:
+      jobs:
+        - localstack-test
+      

--- a/src/examples/startup-async.yml
+++ b/src/examples/startup-async.yml
@@ -1,7 +1,9 @@
 description: |
   This example illustrates asynchronous LocalStack startup, to optimize the build time by running your test initialization tasks in parallel.
 
-  The sample first uses the `localstack/start` command to start up LocalStack in the background, then performs custom application initialization commands (illustrated via the first `echo` command), and then finally uses the `localstack/wait` command before proceeding with the actual application build logic (second `echo` command).
+  The sample first uses the `localstack/start` command to start up LocalStack in the background,
+  then performs custom application initialization commands (illustrated via the first `echo` command),
+  and then finally uses the `localstack/wait` command before proceeding with the actual application build logic (second `echo` command).
 
 usage:
   version: 2.1

--- a/src/examples/startup-async.yml
+++ b/src/examples/startup-async.yml
@@ -19,3 +19,8 @@ usage:
         - localstack/wait
         - run:
             command: echo "Now LocalStack has fully started up, and is ready to use!"
+
+  workflows:
+    localstack-test:
+      jobs:
+        - localstack-test


### PR DESCRIPTION
Currently the [Orb's documentation page](https://circleci.com/developer/orbs/orb/localstack/platform) adds the workflows definition with the default `null`:
```
version: '2.1'
orbs:
  localstack: localstack/platform@1.0
jobs:
  localstack-test:
    executor: localstack/default
    steps:
      - localstack/startup
      - run:
          command: |
            awslocal s3 mb s3://test
            awslocal s3 ls
workflows: null # <-- This is invalid
```
When just copying the example, the pipeline fails on CircleCI since the pipeline does not define any workflows or build jobs.
This PR adds the workflow definition to the examples, such that they can be directly used and tested: