### PR TITLE
[semver:minor] Handle new default localstack container name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.0.0] - 2023-11-02
+- Major release supporting LocalStack Pro v3.
+- The default container name has been updated to `localstack-main`
+
 ## [2.0.0] - 2023-08-30
 - Major release supporting LocalStack Pro v2.
 - The `image-tag` parameter has been removed. Please use the environment variable `IMAGE_NAME` instead if you want to change the used Docker image or tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 All notable changes to this project will be documented in this file.
 
 ## [2.1.0] - 2023-11-03
-- The default container name has been updated to `localstack-main`, but we still manage containers with the name `localstack_main`
+- Preparing the Orb for the release of LocalStack 3.0.
+  - The default container name will be renamed from `localstack-main` to `localstack_main`.
+  - This change is backwards compatible, it will fall back to the old container name for now (and will use the new container name once LocalStack 3.0 is released).
 
 ## [2.0.0] - 2023-08-30
 - Major release supporting LocalStack Pro v2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
-## [3.0.0] - 2023-11-02
-- Major release supporting LocalStack Pro v3.
-- The default container name has been updated to `localstack-main`
+## [2.1.0] - 2023-11-02
+- The default container name has been updated to `localstack-main`, but we still manage containers with the name `localstack_main`
 
 ## [2.0.0] - 2023-08-30
 - Major release supporting LocalStack Pro v2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.1.0] - 2023-11-02
+## [2.1.0] - 2023-11-03
 - The default container name has been updated to `localstack-main`, but we still manage containers with the name `localstack_main`
 
 ## [2.0.0] - 2023-08-30

--- a/src/commands/stop.yml
+++ b/src/commands/stop.yml
@@ -7,4 +7,4 @@ steps:
   - run:
       name: Stop LocalStack container
       command: |
-        docker rm -f localstack-main
+        docker rm -f localstack-main localstack_main

--- a/src/commands/stop.yml
+++ b/src/commands/stop.yml
@@ -1,10 +1,10 @@
 description: |
   Stop the currently running LocalStack instance.
 
-  This command stops the LocalStack container running in the current build job (using the container name, "localstack_main" by default).
+  This command stops the LocalStack container running in the current build job (using the container name, "localstack-main" by default).
 
 steps:
   - run:
       name: Stop LocalStack container
       command: |
-        docker rm -f localstack_main
+        docker rm -f localstack-main

--- a/src/commands/wait.yml
+++ b/src/commands/wait.yml
@@ -8,9 +8,9 @@ steps:
       name: Wait for LocalStack to be ready
       command: |
         for i in {1..45}; do
-          if [ `docker logs localstack_main | grep 'Ready.'` ]; then
+          if [ `docker logs localstack-main | grep 'Ready.'` ]; then
             break
           fi
           sleep 1
         done
-        # docker logs localstack_main
+        # docker logs localstack-main

--- a/src/commands/wait.yml
+++ b/src/commands/wait.yml
@@ -11,6 +11,9 @@ steps:
           if [ `docker logs localstack-main | grep 'Ready.'` ]; then
             break
           fi
+          if [ `docker logs localstack_main | grep 'Ready.'` ]; then
+            break
+          fi
           sleep 1
         done
         # docker logs localstack-main

--- a/src/examples/aws-cli-commands.yml
+++ b/src/examples/aws-cli-commands.yml
@@ -8,7 +8,7 @@ usage:
   version: 2.1
 
   orbs:
-    localstack: localstack/platform@2.0
+    localstack: localstack/platform@3.0
 
   jobs:
     localstack-test:

--- a/src/examples/aws-cli-commands.yml
+++ b/src/examples/aws-cli-commands.yml
@@ -8,7 +8,7 @@ usage:
   version: 2.1
 
   orbs:
-    localstack: localstack/platform@3.0
+    localstack: localstack/platform@2.1
 
   jobs:
     localstack-test:

--- a/src/examples/startup-async.yml
+++ b/src/examples/startup-async.yml
@@ -9,7 +9,7 @@ usage:
   version: 2.1
 
   orbs:
-    localstack: localstack/platform@2.0
+    localstack: localstack/platform@3.0
 
   jobs:
     localstack-test:

--- a/src/examples/startup-async.yml
+++ b/src/examples/startup-async.yml
@@ -9,7 +9,7 @@ usage:
   version: 2.1
 
   orbs:
-    localstack: localstack/platform@3.0
+    localstack: localstack/platform@2.1
 
   jobs:
     localstack-test:


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:

<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->

Update the name of the container to `localstack-main`. Also handle the old container name of `localstack_main` until we have fully switched over to the new container name.

## Motivation:

<!---
  Share any open issues this PR references or otherwise describe the motivation to submit this pull request.
 -->

Hyphens are not allowed in domain names. Docker container names are sometimes used as URLs, and some tools (e.g. `boto3`) refuse to connect to `localstack_main`.

For more details, see the corresponding LocalStack change: https://github.com/localstack/localstack/pull/9469

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] Usage Example version numbers have been updated.
- [x] Changelog has been updated.
