### PR TITLE
[semver:minor] deprecate `localstack/platform` orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,11 +25,9 @@ jobs:
     executor: localstack/default
     steps:
       - run:
-          name: Manually clone Repository
+          name: Manually Clone Repository
           command: |
-            echo "$CIRCLE_BRANCH"
-            echo "$CIRCLE_REPOSITORY_URL"
-            git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL"
+            git clone -b "$CIRCLE_BRANCH" https://github.com/localstack/ci-plugin-circleci.git
       - localstack/startup
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,7 @@ jobs:
   integration-test-1:
     executor: localstack/default
     steps:
-      - checkout:
-          force-ssh: false
+      - checkout
       - localstack/startup
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,12 @@ jobs:
   integration-test-1:
     executor: localstack/default
     steps:
-      - checkout
+      - run:
+          name: Manually clone Repository
+          command: |
+            echo "$CIRCLE_BRANCH"
+            echo "$CIRCLE_REPOSITORY_URL"
+            git clone -b "$CIRCLE_BRANCH" "$CIRCLE_REPOSITORY_URL"
       - localstack/startup
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
   integration-test-1:
     executor: localstack/default
     steps:
-      - checkout
+      - checkout:
           force-ssh: false
       - localstack/startup
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
     executor: localstack/default
     steps:
       - checkout
+          force-ssh: false
       - localstack/startup
       - run:
           command: |

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> The `localstack/platform` orb is now deprecated. Official support for the `localstack/platform` orb is no longer provided. It is still available for existing users but is now **unlisted** from the Orb Registry page.
+
 # LocalStack CircleCI Orb
 
 [![CircleCI Build Status](https://circleci.com/gh/localstack/ci-plugin-circleci.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/localstack/ci-plugin-circleci)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]
-> The `localstack/platform` orb is now deprecated. Official support for the `localstack/platform` orb is no longer provided. It is still available for existing users but is now **unlisted** from the Orb Registry page.
+> The `localstack/platform` orb is now deprecated. This means official support for the `localstack/platform` orb is no longer provided. It is still available usage but is now **unlisted** from the Orb Registry page.
 
 # LocalStack CircleCI Orb
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,6 +1,7 @@
 version: 2.1
 
 description: >
+  Note: This orb has now been deprecated and will no longer be actively supported.
   Easily run integration tests with LocalStack, the local cloud testing platform.
 
   This Orb provides a collection of useful, common, and parameterized tasks and commands to facilitate testing of your cloud application using LocalStack.


### PR DESCRIPTION
## Changes
- Updated the README.md to add a deprecation warning banner.
<img width="921" height="478" alt="image" src="https://github.com/user-attachments/assets/79742be8-efd8-4802-9d67-e5a35f042597" />

- Unlisted the `localstack/platform` orb. This essentially makes it still usable but no longer lists this orb when running `orb list`. The documentation page is still viewable if known, or if this exact command is run `cirecleci orb source localstack/platform`.
- This should be enough to not impact existing users drastically while still indicating a lack of support for this orb.
- As of creating this PR, the orb has already been unlisted.
- LocalStack CLI changes have already been merged meaning that users of this Orb will need to update their environment variables to use an auth token if not already provided.